### PR TITLE
feat: render mutable endpoints w/out custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,13 @@ The only way to test the solutions is to run it locally:
         - [x] Render all endpoints;
         - [x] Render & "assemble" endpoints in the specified page; <br />
               **To enable this feature, insert in the documentation of each endpoint a field like `path: /pages/page1`**
-        - [ ] Render custom types - Struct & Enum;
-      - [ ] Mutable:
-        - [ ] Render single endpoint w/ its inputs & outputs;
-        - [ ] Render all endpoints;
-        - [ ] Render & "assemble" endpoints in the specified page;
-        - [ ] Render custom types - Struct & Enum;
+        - [ ] Handle custom types - Struct & Enum;
+      - [x] Mutable:
+        - [x] Render single endpoint w/ its inputs & outputs;
+        - [x] Render all endpoints;
+        - [x] Render & "assemble" endpoints in the specified page;
+              **To enable this feature, insert in the documentation of each endpoint a field like `path: /pages/page1`**
+        - [ ] Handle custom types - Struct & Enum;
       - [ ] Custom types;
   - [x] Fix MultiversX sdk UI styling;
   - [x] Update [dApp boilerplate][dapp-boilerplate] to the last version;

--- a/back-end/src/rendering/mod.rs
+++ b/back-end/src/rendering/mod.rs
@@ -1,3 +1,4 @@
+pub mod mutable_endpoint;
 pub mod page;
 pub mod readonly_endpoint;
 pub mod routes;

--- a/back-end/src/rendering/mutable_endpoint.rs
+++ b/back-end/src/rendering/mutable_endpoint.rs
@@ -1,0 +1,28 @@
+use askama::Template;
+
+use crate::analysis::endpoints::{ReadonlyEndpointInput, ReadonlyEndpointOutput};
+
+#[derive(Template)]
+#[template(path = "mutable-endpoint.ts", escape = "none")]
+struct ReadonlyEndpointTemplate<'a> {
+    component_name: &'a String,
+    endpoint_name: &'a String,
+    inputs: &'a Vec<ReadonlyEndpointInput>,
+    outputs: &'a Vec<ReadonlyEndpointOutput>,
+}
+
+pub fn render(
+    component_name: &String,
+    endpoint_name: &String,
+    inputs: &Vec<ReadonlyEndpointInput>,
+    outputs: &Vec<ReadonlyEndpointOutput>,
+) -> String {
+    let template = ReadonlyEndpointTemplate {
+        component_name,
+        endpoint_name,
+        inputs,
+        outputs,
+    };
+
+    template.render().unwrap()
+}

--- a/back-end/templates/mutable-endpoint.ts
+++ b/back-end/templates/mutable-endpoint.ts
@@ -1,0 +1,91 @@
+import { sendTransactions } from '@multiversx/sdk-dapp/services';
+import { refreshAccount } from '@multiversx/sdk-dapp/utils';
+import React, { useState } from 'react';
+import { contractAddress } from '../../config/devnet';
+import Button from '../button';
+import Container from '../container';
+import NumericInput from '../inputs/numeric-input';
+import TextInput from '../inputs/text-input';
+
+export default function {{component_name}}Endpoint() {
+	{% if inputs.len() > 0 %}
+		{% for input in inputs %}
+			const [
+				{{ input.name }}{{ loop.index }}, 
+				set{{ input.name }}{{ loop.index }}
+			] = useState<{{input.type_}}>({{ input.initial_value }});
+		{% endfor %}
+	{% endif %}
+
+	return (
+		<Container id="{{ endpoint_name }}-endpoint" title="{{ endpoint_name }} endpoint">
+			{% if inputs.len() > 0 %}
+				{% for input in inputs %}
+					{% if input.type_.contains("number") %}
+						<NumericInput
+							id="increment"
+							label="Increment value"
+							placeholder="Insert increment value"
+							value={ {{ input.name }}{{ loop.index }} }
+							setValue={ set{{ input.name }}{{ loop.index }} }
+						/>
+					{% else if input.type_.contains("string") %}
+						<TextInput
+							id="increment"
+							label="Increment value"
+							placeholder="Insert increment value"
+							value={ {{ input.name }}{{ loop.index }} }
+							setValue={ set{{ input.name }}{{ loop.index }} }
+						/>
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+
+			<Button
+				title="Send transaction"
+				onClick={() => sendTransaction(
+					{% if inputs.len() > 0 %}
+						{% for input in inputs %}
+							{{ input.name }}{{ loop.index }}, 
+						{% endfor %}
+					{% endif %}
+				)}
+			>
+				Send transaction
+			</Button>
+		</Container>
+	);
+}
+
+async function sendTransaction(
+	{% if inputs.len() > 0 %}
+		{% for input in inputs %}
+			{{ input.name }}{{ loop.index }}: {{ input.type_ }}, 
+		{% endfor %}
+	{% endif %}
+) {
+	const parsedNumber = Number.parseInt(value as unknown as string);
+	const hexNumber = parsedNumber.toString(16);
+
+	const data = hexNumber.length % 2 === 0 ? hexNumber : `0${hexNumber}`;
+
+	const transaction = {
+		value: 0,
+		data: `{{ endpoint_name }}@${data}`,
+		receiver: contractAddress,
+		gasLimit: '2000000',
+	};
+
+	await refreshAccount();
+
+	await sendTransactions({
+		transactions: transaction,
+		transactionsDisplayInfo: {
+			processingMessage: 'Processing {{ endpoint_name }} transaction',
+			errorMessage:
+				'An error has occured during {{ endpoint_name }} transaction',
+			successMessage: '{{ endpoint_name }} transaction successful',
+		},
+	});
+}
+


### PR DESCRIPTION
Implementation to analyse the endpoints array from the smart contract ABI and render only the mutable ones.
Moreover, if the docs array of an endpoint contains a path - e.g. "path: /pages/page1" - the endpoint will be "assembled" into that page, instead of being rendered into a custom-hook folder on its own, which is the default.
**The only thing missing is the serialization of the endpoint parameters.**