### PR TITLE
feat: readonly endpoint ip serialization

### DIFF
--- a/back-end/src/analysis/endpoints.rs
+++ b/back-end/src/analysis/endpoints.rs
@@ -161,6 +161,20 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 initial_value: "\"\"".to_string(),
                 args_serializer: "AddressValue".to_string(),
             }),
+            "TokenIdentifier" => endpoint_inputs.push(EndpointIO {
+                getter: input.name().to_string().snake_to_camel_case(),
+                setter: format!(
+                    "set{}",
+                    input
+                        .name()
+                        .to_string()
+                        .snake_to_camel_case()
+                        .capitalize_first_letter()
+                ),
+                type_: "string".to_string(),
+                initial_value: "\"\"".to_string(),
+                args_serializer: "TokenIdentifierValue".to_string(),
+            }),
             "usize" | "u8" | "u16" | "u32" | "u64" | "BigUint" => {
                 endpoint_inputs.push(EndpointIO {
                     getter: input.name().to_string().snake_to_camel_case(),
@@ -175,7 +189,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                     type_: "number".to_string(),
                     initial_value: "0".to_string(),
                     args_serializer: match input.type_().as_str() {
-                        "usize" => "U8Value".to_string(),
+                        "usize" => "U32Value".to_string(),
                         "u8" => "U8Value".to_string(),
                         "u16" => "U16Value".to_string(),
                         "u32" => "U32Value".to_string(),
@@ -198,7 +212,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 type_: "number".to_string(),
                 initial_value: "0".to_string(),
                 args_serializer: match input.type_().as_str() {
-                    "isize" => "I8Value".to_string(),
+                    "isize" => "I32Value".to_string(),
                     "i8" => "I8Value".to_string(),
                     "i16" => "I16Value".to_string(),
                     "i32" => "I32Value".to_string(),
@@ -207,7 +221,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                     _ => "".to_string(),
                 },
             }),
-            "bytes" | "utf-8 string" => endpoint_inputs.push(EndpointIO {
+            "bytes" => endpoint_inputs.push(EndpointIO {
                 getter: input.name().to_string().snake_to_camel_case(),
                 setter: format!(
                     "set{}",
@@ -220,6 +234,20 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 type_: "string".to_string(),
                 initial_value: "\"\"".to_string(),
                 args_serializer: "BytesValue".to_string(),
+            }),
+            "utf-8 string" => endpoint_inputs.push(EndpointIO {
+                getter: input.name().to_string().snake_to_camel_case(),
+                setter: format!(
+                    "set{}",
+                    input
+                        .name()
+                        .to_string()
+                        .snake_to_camel_case()
+                        .capitalize_first_letter()
+                ),
+                type_: "string".to_string(),
+                initial_value: "\"\"".to_string(),
+                args_serializer: "StringValue".to_string(),
             }),
             "bool" => endpoint_inputs.push(EndpointIO {
                 getter: input.name().to_string().snake_to_camel_case(),
@@ -246,7 +274,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "string[]".to_string(),
-                initial_value: "[\"\"]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             "List<usize>" | "List<u8>" | "List<u16>" | "List<u32>" | "List<u64>"
@@ -261,7 +289,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "number[]".to_string(),
-                initial_value: "[0]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             "variadic<usize>" | "variadic<u8>" | "variadic<u16>" | "variadic<u32>"
@@ -276,7 +304,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "number[]".to_string(),
-                initial_value: "[0]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             "List<isize>" | "List<i8>" | "List<i16>" | "List<i32>" | "List<i64>"
@@ -291,7 +319,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "number[]".to_string(),
-                initial_value: "[0]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             "variadic<isize>" | "variadic<i8>" | "variadic<i16>" | "variadic<i32>"
@@ -306,7 +334,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "number[]".to_string(),
-                initial_value: "[0]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             "List<bytes>" | "List<utf-8 string>" | "variadic<bytes>" | "variadic<utf-8 string>" => {
@@ -321,7 +349,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                             .capitalize_first_letter()
                     ),
                     type_: "string[]".to_string(),
-                    initial_value: "[\"\"]".to_string(),
+                    initial_value: "[]".to_string(),
                     args_serializer: "".to_string(),
                 })
             }
@@ -336,7 +364,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                         .capitalize_first_letter()
                 ),
                 type_: "boolean[]".to_string(),
-                initial_value: "[false]".to_string(),
+                initial_value: "[]".to_string(),
                 args_serializer: "".to_string(),
             }),
             _ => {}
@@ -354,6 +382,13 @@ fn get_endpoint_outputs(outputs: &Vec<Output>) -> Vec<EndpointIO> {
             "Address" => endpoint_outputs.push(EndpointIO {
                 getter: "address".to_string(),
                 setter: "setAddress".to_string(),
+                type_: "string".to_string(),
+                initial_value: "\"\"".to_string(),
+                args_serializer: "".to_string(),
+            }),
+            "TokenIdentifier" => endpoint_outputs.push(EndpointIO {
+                getter: "tokenIdentifier".to_string(),
+                setter: "setTokenIdentifier".to_string(),
                 type_: "string".to_string(),
                 initial_value: "\"\"".to_string(),
                 args_serializer: "".to_string(),
@@ -380,7 +415,7 @@ fn get_endpoint_outputs(outputs: &Vec<Output>) -> Vec<EndpointIO> {
                 getter: "str".to_string(),
                 setter: "setStr".to_string(),
                 type_: "string".to_string(),
-                initial_value: "0".to_string(),
+                initial_value: "\"\"".to_string(),
                 args_serializer: "".to_string(),
             }),
             "bool" => endpoint_outputs.push(EndpointIO {

--- a/back-end/src/analysis/endpoints.rs
+++ b/back-end/src/analysis/endpoints.rs
@@ -275,8 +275,24 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "string[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: "AddressValue".to_string(),
             }),
+            "List<TokenIdentifier>" | "variadic<TokenIdentifier>" => {
+                endpoint_inputs.push(EndpointIO {
+                    getter: input.name().to_string().snake_to_camel_case(),
+                    setter: format!(
+                        "set{}",
+                        input
+                            .name()
+                            .to_string()
+                            .snake_to_camel_case()
+                            .capitalize_first_letter()
+                    ),
+                    type_: "string[]".to_string(),
+                    initial_value: "[]".to_string(),
+                    args_serializer: "TokenIdentifierValue".to_string(),
+                })
+            }
             "List<usize>" | "List<u8>" | "List<u16>" | "List<u32>" | "List<u64>"
             | "List<BigUint>" => endpoint_inputs.push(EndpointIO {
                 getter: input.name().to_string().snake_to_camel_case(),
@@ -290,7 +306,20 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "number[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: match input
+                    .type_()
+                    .strip_prefix("List<")
+                    .unwrap()
+                    .trim_end_matches(">")
+                {
+                    "usize" => "U32Value".to_string(),
+                    "u8" => "U8Value".to_string(),
+                    "u16" => "U16Value".to_string(),
+                    "u32" => "U32Value".to_string(),
+                    "u64" => "U64Value".to_string(),
+                    "BigUint" => "BigUIntValue".to_string(),
+                    _ => "".to_string(),
+                },
             }),
             "variadic<usize>" | "variadic<u8>" | "variadic<u16>" | "variadic<u32>"
             | "variadic<u64>" | "variadic<BigUint>" => endpoint_inputs.push(EndpointIO {
@@ -305,7 +334,20 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "number[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: match input
+                    .type_()
+                    .strip_prefix("List<")
+                    .unwrap()
+                    .trim_end_matches(">")
+                {
+                    "usize" => "U32Value".to_string(),
+                    "u8" => "U8Value".to_string(),
+                    "u16" => "U16Value".to_string(),
+                    "u32" => "U32Value".to_string(),
+                    "u64" => "U64Value".to_string(),
+                    "BigUint" => "BigUIntValue".to_string(),
+                    _ => "".to_string(),
+                },
             }),
             "List<isize>" | "List<i8>" | "List<i16>" | "List<i32>" | "List<i64>"
             | "List<BigInt>" => endpoint_inputs.push(EndpointIO {
@@ -320,7 +362,20 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "number[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: match input
+                    .type_()
+                    .strip_prefix("List<")
+                    .unwrap()
+                    .trim_end_matches(">")
+                {
+                    "isize" => "I32Value".to_string(),
+                    "i8" => "I8Value".to_string(),
+                    "i16" => "I16Value".to_string(),
+                    "i32" => "I32Value".to_string(),
+                    "i64" => "I64Value".to_string(),
+                    "BigInt" => "BigIntValue".to_string(),
+                    _ => "".to_string(),
+                },
             }),
             "variadic<isize>" | "variadic<i8>" | "variadic<i16>" | "variadic<i32>"
             | "variadic<i64>" | "variadic<BigInt>" => endpoint_inputs.push(EndpointIO {
@@ -335,24 +390,49 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "number[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: match input
+                    .type_()
+                    .strip_prefix("List<")
+                    .unwrap()
+                    .trim_end_matches(">")
+                {
+                    "isize" => "I32Value".to_string(),
+                    "i8" => "I8Value".to_string(),
+                    "i16" => "I16Value".to_string(),
+                    "i32" => "I32Value".to_string(),
+                    "i64" => "I64Value".to_string(),
+                    "BigInt" => "BigIntValue".to_string(),
+                    _ => "".to_string(),
+                },
             }),
-            "List<bytes>" | "List<utf-8 string>" | "variadic<bytes>" | "variadic<utf-8 string>" => {
-                endpoint_inputs.push(EndpointIO {
-                    getter: input.name().to_string().snake_to_camel_case(),
-                    setter: format!(
-                        "set{}",
-                        input
-                            .name()
-                            .to_string()
-                            .snake_to_camel_case()
-                            .capitalize_first_letter()
-                    ),
-                    type_: "string[]".to_string(),
-                    initial_value: "[]".to_string(),
-                    args_serializer: "".to_string(),
-                })
-            }
+            "List<bytes>" | "variadic<bytes>" => endpoint_inputs.push(EndpointIO {
+                getter: input.name().to_string().snake_to_camel_case(),
+                setter: format!(
+                    "set{}",
+                    input
+                        .name()
+                        .to_string()
+                        .snake_to_camel_case()
+                        .capitalize_first_letter()
+                ),
+                type_: "string[]".to_string(),
+                initial_value: "[]".to_string(),
+                args_serializer: "BytesValue".to_string(),
+            }),
+            "List<utf-8 string>" | "variadic<utf-8 string>" => endpoint_inputs.push(EndpointIO {
+                getter: input.name().to_string().snake_to_camel_case(),
+                setter: format!(
+                    "set{}",
+                    input
+                        .name()
+                        .to_string()
+                        .snake_to_camel_case()
+                        .capitalize_first_letter()
+                ),
+                type_: "string[]".to_string(),
+                initial_value: "[]".to_string(),
+                args_serializer: "StringValue".to_string(),
+            }),
             "List<bool>" | "variadic<bool>" => endpoint_inputs.push(EndpointIO {
                 getter: input.name().to_string().snake_to_camel_case(),
                 setter: format!(
@@ -365,7 +445,7 @@ fn get_endpoint_inputs(inputs: &Vec<Field>) -> Vec<EndpointIO> {
                 ),
                 type_: "boolean[]".to_string(),
                 initial_value: "[]".to_string(),
-                args_serializer: "".to_string(),
+                args_serializer: "BooleanValue".to_string(),
             }),
             _ => {}
         }

--- a/back-end/src/rendering/readonly_endpoint.rs
+++ b/back-end/src/rendering/readonly_endpoint.rs
@@ -8,6 +8,7 @@ struct ReadonlyEndpointTemplate<'a> {
     hook_name: &'a String,
     function_name: &'a String,
     endpoint_name: &'a String,
+    does_inputs_include_list: &'a bool,
     does_outputs_include_address: &'a bool,
     inputs: &'a Vec<EndpointIO>,
     outputs: &'a Vec<EndpointIO>,
@@ -20,6 +21,8 @@ pub fn render(
     outputs: &Vec<EndpointIO>,
 ) -> String {
     let function_name = &endpoint_name.snake_to_camel_case();
+
+    let does_inputs_include_list = inputs.iter().any(|input| input.type_.contains("[]"));
     let does_outputs_include_address = outputs
         .iter()
         .any(|output| output.getter.contains("Address"));
@@ -28,6 +31,7 @@ pub fn render(
         hook_name,
         function_name,
         endpoint_name,
+        does_inputs_include_list: &does_inputs_include_list,
         does_outputs_include_address: &does_outputs_include_address,
         inputs,
         outputs,

--- a/back-end/templates/readonly-endpoint.ts
+++ b/back-end/templates/readonly-endpoint.ts
@@ -15,6 +15,9 @@ import {
   {% if does_outputs_include_address %}
     , Address
   {% endif %}
+  {% if does_inputs_include_list %}
+    , List
+  {% endif %}
 } from '@multiversx/sdk-core/out';
 
 {% if inputs.len() > 0 %}
@@ -59,13 +62,27 @@ export default function {{ hook_name }}(
         {% if inputs.len() > 0 %}
           args: [
             {% for input in inputs %}
-              {% if input.args_serializer != "" %}
-                {% if input.args_serializer == "AddressValue" %}
-                  new AddressValue(new Address({{ input.getter }})),
-                {% else if input.args_serializer == "BytesValue" %}
-                  BytesValue.fromUTF8({{ input.getter }}),
-                {% else %}
-                  new {{ input.args_serializer }}({{ input.getter }}),
+              {% if input.type_.contains("[]") %}
+                {% if input.args_serializer != "" %}
+                  List.fromItems({{ input.getter}}.map((value) => {
+                    {% if input.args_serializer == "AddressValue" %}
+                      return new AddressValue(new Address(value))
+                    {% else if input.args_serializer == "BytesValue" %}
+                      return BytesValue.fromUTF8(value)
+                    {% else %}
+                      return new {{ input.args_serializer }}(value)
+                    {% endif %}
+                  })),
+                {% endif %}
+              {% else %}
+                {% if input.args_serializer != "" %}
+                  {% if input.args_serializer == "AddressValue" %}
+                    new AddressValue(new Address({{ input.getter }})),
+                  {% else if input.args_serializer == "BytesValue" %}
+                    BytesValue.fromUTF8({{ input.getter }}),
+                  {% else %}
+                    new {{ input.args_serializer }}({{ input.getter }}),
+                  {% endif %}
                 {% endif %}
               {% endif %}
             {% endfor %}

--- a/back-end/templates/readonly-endpoint.ts
+++ b/back-end/templates/readonly-endpoint.ts
@@ -21,7 +21,11 @@ import {
   import {
     {% for input in inputs %}
       {% if input.args_serializer != "" %}
-        {{ input.args_serializer }},
+        {% if input.args_serializer == "AddressValue" %}
+          AddressValue, Address,
+        {% else %}
+          {{ input.args_serializer }},
+        {% endif %}
       {% endif %}
     {% endfor %}
   } from '@multiversx/sdk-core';
@@ -55,9 +59,15 @@ export default function {{ hook_name }}(
         {% if inputs.len() > 0 %}
           args: [
             {% for input in inputs %}
-                {% if input.args_serializer != "" %}
+              {% if input.args_serializer != "" %}
+                {% if input.args_serializer == "AddressValue" %}
+                  new AddressValue(new Address({{ input.getter }})),
+                {% else if input.args_serializer == "BytesValue" %}
+                  BytesValue.fromUTF8({{ input.getter }}),
+                {% else %}
                   new {{ input.args_serializer }}({{ input.getter }}),
                 {% endif %}
+              {% endif %}
             {% endfor %}
           ]
         {% endif %}


### PR DESCRIPTION
Readonly endpoint input serialization.
Types supported:
- [x] **Basic types**:
    - [x] Numerical types:
      - [x] Unsigned: usize | u8 | u16 | u32 | u64 | BigUint
      - [x] Signed: isize | i8 | i16 | i32 | i64 | BigInt
    - [x] Booleans: bool
    - [x] (MANAGED BUFFER) Bytes arrays: bytes
    - [x] (STRING) Text: utf-8 string
    - [x] Address: Address
    - [x] TokenIdentifier: TokenIdentifier
 - [x] **Composite types:**
    - [x] Variable-length lists (List):
      - [x] Numerical types:
        - [x] Unsigned: usize | u8 | u16 | u32 | u64 | BigUint
        - [x] Signed: isize | i8 | i16 | i32 | i64 | BigInt
      - [x] Booleans: bool
      - [x] (MANAGED BUFFER) Bytes arrays: bytes
      - [x] (STRING) Text: utf-8 string
      - [x] Address: Address
      - [x] TokenIdentifier: TokenIdentifier